### PR TITLE
Remove /cgi-bin redirections from the project (migrated to www-auxiliary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Routed paths
 
 * /accessibility.en.shtml
 * /accessibility.fr.shtml
-* /cgi-bin/csoldap
 * /css
 * /errors
 * /images

--- a/test_web2010_urls.py
+++ b/test_web2010_urls.py
@@ -7,9 +7,6 @@ BASE_URL = 'http://localhost:8080'
 paths = {
   '/accessibility.en.shtml': 200,
   '/accessibility.fr.shtml': 200,
-  '/cgi-bin/csoldap/browse?unit=10339': 302,
-  '/cgi-bin/csoldap?sciper=199918': 302,
-  '/cgi-bin/csoldap/simple?sciper=263877': 302,
   '/cssss': 404,
   '/css/print.css': 200,
   '/css/epfl.css': 200,

--- a/web2010_nginx.conf
+++ b/web2010_nginx.conf
@@ -57,12 +57,6 @@ server {
     ssi on;
   }
 
-  location ^~ /cgi-bin/ {
-    add_header Cache-Control "max-age=0";
-    rewrite ^/cgi-bin/csoldap/browse(.*)$ https://search.epfl.ch/browseunit.do$1;
-    rewrite ^/cgi-bin/csoldap(.*)$ https://search.epfl.ch/directory.do$1;
-  }
-
   # Enable Gzip compression.
   gzip on;
 


### PR DESCRIPTION
**Description**

`/cgi-bin` Redirections are moved to www-auxiliary → https://github.com/epfl-si/www/blob/main/ansible/roles/www/templates/nginx.conf